### PR TITLE
Address initialization-order compiler warnings.

### DIFF
--- a/pxr/imaging/plugin/hdOSPRay/mesh.cpp
+++ b/pxr/imaging/plugin/hdOSPRay/mesh.cpp
@@ -44,13 +44,13 @@ std::mutex g_mutex;
 HdOSPRayMesh::HdOSPRayMesh(SdfPath const& id,
                            SdfPath const& instancerId)
         : HdMesh(id, instancerId)
+        , _ospMesh(nullptr)
         , _adjacencyValid(false)
         , _normalsValid(false)
         , _refined(false)
         , _smoothNormals(false)
         , _doubleSided(false)
         , _cullStyle(HdCullStyleDontCare)
-        , _ospMesh(nullptr)
 {
 }
 
@@ -457,7 +457,7 @@ HdOSPRayMesh::_PopulateRtMesh(HdSceneDelegate* sceneDelegate,
   else {
     bool newInstance = false;
     if (_ospInstances.size() == 0) {
-      float* xfm = _transform.GetArray();
+      //float* xfm = _transform.GetArray();
       //convert aligned matrix to unalighned 4x3 matrix
       auto instance = ospNewInstance(instanceModel, (osp::affine3f&)ospcommon::one);
       _ospInstances.push_back(instance);
@@ -490,10 +490,10 @@ HdOSPRayMesh::_PopulateRtMesh(HdSceneDelegate* sceneDelegate,
       ospAddGeometry(model, instance);
     }
   } else {
-    for (auto instance : _ospInstances) {
+//    for (auto instance : _ospInstances) {
       //std::lock_guard<std::mutex> lock(g_mutex);
 //      ospRemoveGeometry(model, instance);
-    }
+//    }
   }
 
   // Clean all dirty bits.

--- a/pxr/imaging/plugin/hdOSPRay/renderPass.cpp
+++ b/pxr/imaging/plugin/hdOSPRay/renderPass.cpp
@@ -45,12 +45,12 @@ HdOSPRayRenderPass::HdOSPRayRenderPass(HdRenderIndex *index,
     : HdRenderPass(index, collection)
     , _pendingResetImage(false)
     , _pendingModelUpdate(true)
+    , _renderer(renderer)
     , _sceneVersion(sceneVersion)
     , _lastRenderedVersion(0)
     , _width(0)
     , _height(0)
     , _model(model)
-    , _renderer(renderer)
     , _inverseViewMatrix(1.0f) // == identity
     , _inverseProjMatrix(1.0f) // == identity
     , _clearColor(0.0707f, 0.0707f, 0.0707f)
@@ -124,7 +124,7 @@ HdOSPRayRenderPass::IsConverged() const
     // use the sample count from pixel(0,0).
     unsigned int samplesToConvergence =
         HdOSPRayConfig::GetInstance().samplesToConvergence;
-    return (_numSamplesAccumulated >= samplesToConvergence);
+    return ((unsigned int)_numSamplesAccumulated >= samplesToConvergence);
 }
 
 void


### PR DESCRIPTION
Hi, we're probably on different compilers; mine warns about initializer order. Ignore this as needed. Also, please note the branch i chose, maybe 'dev' was more appropriate.

-- The C compiler identification is GNU 4.8.5
-- The CXX compiler identification is GNU 4.8.5
